### PR TITLE
Add hero banner image to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Tollbooth Authority
 
+<p align="center">
+  <img src="https://raw.githubusercontent.com/lonniev/tollbooth-dpyc/main/docs/tollbooth-hero.png" alt="Milo drives the Lightning Turnpike — Don't Pester Your Customer" width="800">
+</p>
+
 **The institution that built the infrastructure.**
 
 > *The metaphors in this project are drawn with admiration from* The Phantom Tollbooth *by Norton Juster, illustrated by Jules Feiffer (1961). Milo, Tock, the Tollbooth, Dictionopolis, and Digitopolis are creations of Mr. Juster's extraordinary imagination. We just built the payment infrastructure.*


### PR DESCRIPTION
## Summary

- Adds the same Phantom Tollbooth hero banner from tollbooth-dpyc to the top of the README for consistent branding across repos

## Test plan

- [ ] README renders on GitHub with hero image displayed

🤖 Generated with [Claude Code](https://claude.com/claude-code)