### PR TITLE
Vault flush durability: caching, shutdown timeout, reconciliation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "python-dotenv>=1.0.0",
     "PyJWT>=2.8.0",
     "cryptography>=42.0.0",
-    "tollbooth-dpyc>=0.1.5",
+    "tollbooth-dpyc>=0.1.6",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
- **TheBrainVault caching**: daily child ID + index caching reduces `store_ledger` from 3-4 API calls to 1 on cache hit
- **Shutdown timeout**: `_graceful_shutdown` wraps flush+stop in `wait_for(timeout=8s)`, removes `snapshot_all` (was creating extra thoughts and delaying shutdown)
- **Reconciliation hook**: `tax_balance` auto-reconciles pending invoices once per user per process lifetime
- **Pin**: `tollbooth-dpyc>=0.1.6` for flush retry + reconciliation function

## Test plan
- [ ] All 27 existing tests pass
- [ ] Deploy after tollbooth-dpyc v0.1.6 is published on PyPI
- [ ] Verify `tax_balance` reconciliation on first call per process

🤖 Generated with [Claude Code](https://claude.com/claude-code)