### PR TITLE
Add upstream tax payout for Authority chain revenue backflow

### DIFF
--- a/src/tollbooth_authority/config.py
+++ b/src/tollbooth_authority/config.py
@@ -29,6 +29,13 @@ class AuthoritySettings(BaseSettings):
     tax_rate_percent: float = 2.0
     tax_min_sats: int = 10
 
+    # Upstream Authority chain — revenue backflow
+    # When an operator buys cert_sats from this Authority, fire a % payout
+    # to the upstream Authority's Lightning Address. Empty = Prime Authority.
+    upstream_authority_address: str = ""
+    upstream_tax_percent: float = 2.0
+    upstream_tax_min_sats: int = 10
+
     # Certificate TTL
     certificate_ttl_seconds: int = 600
 


### PR DESCRIPTION
## Summary
- Enables Authority chaining (TA1 <- TA2 <- TA3) where revenue flows upstream
- When an operator buys cert_sats and the invoice settles, the Authority fires a % payout to its upstream Authority's Lightning Address
- Prime Authorities leave `UPSTREAM_AUTHORITY_ADDRESS` empty — no upstream payouts fire
- Reuses existing `check_payment_tool` royalty payout infrastructure — zero new dependencies

## Config
```
UPSTREAM_AUTHORITY_ADDRESS=upstream@btcpay.example.com
UPSTREAM_TAX_PERCENT=2.0
UPSTREAM_TAX_MIN_SATS=10
```

## Changes
- `config.py`: 3 new fields in `AuthoritySettings`
- `server.py`: `check_tax_payment` passes upstream config as royalty params; `operator_status` surfaces upstream chain info
- `test_tools.py`: 3 new tests (upstream fires, Prime skips, status shows chain)

## Test plan
- [x] All 30 tests pass
- [ ] Deploy with `UPSTREAM_AUTHORITY_ADDRESS` set, purchase cert_sats, verify payout fires
- [ ] Deploy without upstream config (Prime), verify no payouts fire

🤖 Generated with [Claude Code](https://claude.com/claude-code)