### PR TITLE
Wire DPYC identity and registry into Authority

### DIFF
--- a/src/tollbooth_authority/certificate.py
+++ b/src/tollbooth_authority/certificate.py
@@ -11,13 +11,15 @@ def create_certificate_claims(
     amount_sats: int,
     tax_sats: int,
     ttl_seconds: int = 600,
+    authority_npub: str = "",
 ) -> dict:
     """Build JWT claims for a certified purchase order.
 
     Returns a dict suitable for passing to ``AuthoritySigner.sign_certificate``.
+    When *authority_npub* is non-empty it is included as a claim.
     """
     now = datetime.now(timezone.utc)
-    return {
+    claims = {
         "jti": str(uuid.uuid4()),
         "sub": operator_id,
         "iat": int(now.timestamp()),
@@ -26,3 +28,6 @@ def create_certificate_claims(
         "tax_paid_sats": tax_sats,
         "net_sats": amount_sats - tax_sats,
     }
+    if authority_npub:
+        claims["authority_npub"] = authority_npub
+    return claims

--- a/src/tollbooth_authority/config.py
+++ b/src/tollbooth_authority/config.py
@@ -39,4 +39,13 @@ class AuthoritySettings(BaseSettings):
     # Certificate TTL
     certificate_ttl_seconds: int = 600
 
+    # DPYC Nostr Identity
+    dpyc_authority_npub: str = ""
+    dpyc_upstream_authority_npub: str = ""
+
+    # DPYC Registry enforcement
+    dpyc_registry_url: str = "https://raw.githubusercontent.com/lonniev/dpyc-community/main/members.json"
+    dpyc_registry_cache_ttl_seconds: int = 300
+    dpyc_enforce_membership: bool = False  # opt-in; safe default
+
     model_config = {"env_file": ".env", "extra": "ignore"}

--- a/src/tollbooth_authority/registry.py
+++ b/src/tollbooth_authority/registry.py
@@ -1,0 +1,76 @@
+"""DPYC community registry — cached membership lookup."""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+
+class RegistryError(Exception):
+    """Raised when a registry lookup fails (fail closed)."""
+
+
+class DPYCRegistry:
+    """Cached DPYC community membership lookup via HTTP.
+
+    Fetches the community members.json from the registry URL and caches it
+    with a monotonic-clock TTL. Any HTTP, parse, or structure error raises
+    ``RegistryError`` (fail closed — no silent pass-through).
+    """
+
+    def __init__(self, url: str, cache_ttl_seconds: int = 300) -> None:
+        self._url = url
+        self._ttl = cache_ttl_seconds
+        self._client = httpx.AsyncClient(timeout=10.0)
+        self._cache: list[dict[str, Any]] | None = None
+        self._cache_time: float = 0.0
+
+    async def check_membership(self, npub: str) -> dict[str, Any]:
+        """Return the member record for *npub* or raise ``RegistryError``."""
+        members = await self._fetch()
+
+        for member in members:
+            if member.get("npub") == npub:
+                if member.get("status") != "active":
+                    raise RegistryError(
+                        f"Member {npub} is not active (status={member.get('status')})."
+                    )
+                return member
+
+        raise RegistryError(f"npub {npub} not found in DPYC registry.")
+
+    async def _fetch(self) -> list[dict[str, Any]]:
+        """Return the cached member list, refreshing if stale."""
+        now = time.monotonic()
+        if self._cache is not None and (now - self._cache_time) < self._ttl:
+            return self._cache
+
+        try:
+            resp = await self._client.get(self._url)
+            resp.raise_for_status()
+            data = resp.json()
+        except httpx.HTTPError as e:
+            raise RegistryError(f"Registry fetch failed: {e}") from e
+        except Exception as e:
+            raise RegistryError(f"Registry parse failed: {e}") from e
+
+        if not isinstance(data, list):
+            raise RegistryError("Registry JSON is not a list.")
+
+        self._cache = data
+        self._cache_time = now
+        return data
+
+    def invalidate_cache(self) -> None:
+        """Force the next ``check_membership`` to re-fetch."""
+        self._cache = None
+        self._cache_time = 0.0
+
+    async def close(self) -> None:
+        """Close the underlying HTTP client."""
+        await self._client.aclose()

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,0 +1,132 @@
+"""Tests for DPYCRegistry — cached membership lookup."""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+from tollbooth_authority.registry import DPYCRegistry, RegistryError
+
+
+SAMPLE_MEMBERS = [
+    {"npub": "npub1active000000000000000000000000000000000000000000000000abc", "name": "Alice", "status": "active"},
+    {"npub": "npub1inactive0000000000000000000000000000000000000000000000xyz", "name": "Bob", "status": "inactive"},
+]
+
+REGISTRY_URL = "https://example.com/members.json"
+
+
+def _mock_response(data, status_code=200):
+    resp = httpx.Response(status_code=status_code, json=data, request=httpx.Request("GET", REGISTRY_URL))
+    return resp
+
+
+@pytest.mark.asyncio
+async def test_active_member_lookup():
+    registry = DPYCRegistry(REGISTRY_URL, cache_ttl_seconds=300)
+    registry._client.get = AsyncMock(return_value=_mock_response(SAMPLE_MEMBERS))
+
+    member = await registry.check_membership("npub1active000000000000000000000000000000000000000000000000abc")
+    assert member["name"] == "Alice"
+    assert member["status"] == "active"
+    await registry.close()
+
+
+@pytest.mark.asyncio
+async def test_inactive_member_raises():
+    registry = DPYCRegistry(REGISTRY_URL, cache_ttl_seconds=300)
+    registry._client.get = AsyncMock(return_value=_mock_response(SAMPLE_MEMBERS))
+
+    with pytest.raises(RegistryError, match="not active"):
+        await registry.check_membership("npub1inactive0000000000000000000000000000000000000000000000xyz")
+    await registry.close()
+
+
+@pytest.mark.asyncio
+async def test_unknown_npub_raises():
+    registry = DPYCRegistry(REGISTRY_URL, cache_ttl_seconds=300)
+    registry._client.get = AsyncMock(return_value=_mock_response(SAMPLE_MEMBERS))
+
+    with pytest.raises(RegistryError, match="not found"):
+        await registry.check_membership("npub1unknown0000000000000000000000000000000000000000000000000")
+    await registry.close()
+
+
+@pytest.mark.asyncio
+async def test_http_error_raises():
+    registry = DPYCRegistry(REGISTRY_URL, cache_ttl_seconds=300)
+    registry._client.get = AsyncMock(side_effect=httpx.ConnectError("Connection refused"))
+
+    with pytest.raises(RegistryError, match="fetch failed"):
+        await registry.check_membership("npub1active000000000000000000000000000000000000000000000000abc")
+    await registry.close()
+
+
+@pytest.mark.asyncio
+async def test_invalid_json_raises():
+    registry = DPYCRegistry(REGISTRY_URL, cache_ttl_seconds=300)
+    # Return a response whose .json() raises
+    bad_resp = httpx.Response(200, content=b"not json", request=httpx.Request("GET", REGISTRY_URL))
+    registry._client.get = AsyncMock(return_value=bad_resp)
+
+    with pytest.raises(RegistryError, match="parse failed"):
+        await registry.check_membership("npub1active000000000000000000000000000000000000000000000000abc")
+    await registry.close()
+
+
+@pytest.mark.asyncio
+async def test_non_list_json_raises():
+    registry = DPYCRegistry(REGISTRY_URL, cache_ttl_seconds=300)
+    registry._client.get = AsyncMock(return_value=_mock_response({"members": []}))
+
+    with pytest.raises(RegistryError, match="not a list"):
+        await registry.check_membership("npub1active000000000000000000000000000000000000000000000000abc")
+    await registry.close()
+
+
+@pytest.mark.asyncio
+async def test_cache_hit_within_ttl():
+    registry = DPYCRegistry(REGISTRY_URL, cache_ttl_seconds=300)
+    mock_get = AsyncMock(return_value=_mock_response(SAMPLE_MEMBERS))
+    registry._client.get = mock_get
+
+    await registry.check_membership("npub1active000000000000000000000000000000000000000000000000abc")
+    await registry.check_membership("npub1active000000000000000000000000000000000000000000000000abc")
+
+    # Only one HTTP call — second was a cache hit
+    assert mock_get.call_count == 1
+    await registry.close()
+
+
+@pytest.mark.asyncio
+async def test_cache_expired_refetches():
+    registry = DPYCRegistry(REGISTRY_URL, cache_ttl_seconds=1)
+    mock_get = AsyncMock(return_value=_mock_response(SAMPLE_MEMBERS))
+    registry._client.get = mock_get
+
+    await registry.check_membership("npub1active000000000000000000000000000000000000000000000000abc")
+
+    # Simulate cache expiry by backdating
+    registry._cache_time = time.monotonic() - 2
+
+    await registry.check_membership("npub1active000000000000000000000000000000000000000000000000abc")
+
+    assert mock_get.call_count == 2
+    await registry.close()
+
+
+@pytest.mark.asyncio
+async def test_invalidate_cache_forces_refetch():
+    registry = DPYCRegistry(REGISTRY_URL, cache_ttl_seconds=300)
+    mock_get = AsyncMock(return_value=_mock_response(SAMPLE_MEMBERS))
+    registry._client.get = mock_get
+
+    await registry.check_membership("npub1active000000000000000000000000000000000000000000000000abc")
+    registry.invalidate_cache()
+    await registry.check_membership("npub1active000000000000000000000000000000000000000000000000abc")
+
+    assert mock_get.call_count == 2
+    await registry.close()


### PR DESCRIPTION
## Summary
- Integrates DPYC Honor Chain identity (Nostr npub) as Phase 1 dual-key: operators can activate a DPYC session to key their ledger on npub instead of Horizon ID
- New `DPYCRegistry` module: cached HTTP lookup against community members.json, fail-closed enforcement in `certify_purchase` with full tax+supply rollback on failure
- JWT certificates now include `authority_npub` claim when configured
- 3 new tools: `activate_dpyc`, `get_dpyc_identity`, `check_dpyc_membership`
- 5 new settings (all with safe defaults, enforcement opt-in)
- 22 new tests (8 registry unit tests + 14 tool integration tests)

## Test plan
- [x] `venv/bin/pytest tests/` — 58 passed (was 36, +22 new)
- [ ] Post-deploy: `operator_status` shows `authority_npub`
- [ ] Post-deploy: `activate_dpyc(npub)` → `get_dpyc_identity()` shows npub
- [ ] Post-deploy: `check_dpyc_membership(npub)` returns active member
- [ ] With `DPYC_ENFORCE_MEMBERSHIP=true`: `certify_purchase` with non-member → refused

🤖 Generated with [Claude Code](https://claude.com/claude-code)