### PR TITLE
Fix registry parser to accept members.json wrapper format

### DIFF
--- a/src/tollbooth_authority/registry.py
+++ b/src/tollbooth_authority/registry.py
@@ -59,8 +59,16 @@ class DPYCRegistry:
         except Exception as e:
             raise RegistryError(f"Registry parse failed: {e}") from e
 
-        if not isinstance(data, list):
-            raise RegistryError("Registry JSON is not a list.")
+        # Handle both bare list and {"members": [...]} wrapper formats
+        if isinstance(data, dict):
+            if "members" in data and isinstance(data["members"], list):
+                data = data["members"]
+            else:
+                raise RegistryError(
+                    "Registry JSON object missing 'members' list."
+                )
+        elif not isinstance(data, list):
+            raise RegistryError("Registry JSON is not a list or object.")
 
         self._cache = data
         self._cache_time = now


### PR DESCRIPTION
## Summary
- `check_dpyc_membership` rejected valid members because `members.json` uses `{"members": [...]}` wrapper, not a bare list
- Parser now handles both bare list and wrapper object formats
- Replaced the test that asserted wrapper format should fail with tests for both valid wrapper and genuinely invalid formats
- 60/60 tests pass, no regressions

## Test plan
- [x] `test_wrapper_format_accepted` — `{"members": [...]}` parsed correctly
- [x] `test_object_without_members_key_raises` — `{"data": []}` rejected
- [x] `test_non_list_non_object_raises` — scalar JSON rejected
- [x] All 60 existing tests pass
- [ ] Post-deploy: `check_dpyc_membership(npub1l94pd4...)` returns success

🤖 Generated with [Claude Code](https://claude.com/claude-code)