### PR TITLE
Make npub the sole DPYC identity

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "python-dotenv>=1.0.0",
     "PyJWT>=2.8.0",
     "cryptography>=42.0.0",
-    "tollbooth-dpyc>=0.1.6",
+    "tollbooth-dpyc>=0.1.7",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
- `register_operator` now requires `npub` parameter — validates format, auto-activates DPYC session, uses npub as ledger key
- `_get_effective_user_id()` strict mode: raises `ValueError` if no npub active
- `purchase_tax_credits`, `check_tax_payment`, `tax_balance`, `operator_status` handle ValueError gracefully (return error dict)
- `activate_dpyc` replaced with deprecated stub pointing to `register_operator`
- `get_dpyc_identity` removed
- `operator_status` now includes `dpyc_npub` field
- `certify_purchase` docs updated to reference npub
- Instructions string updated with npub bootstrap flow
- Pins `tollbooth-dpyc>=0.1.7`

## Deployment Order
1. Merge [tollbooth-dpyc#13](https://github.com/lonniev/tollbooth-dpyc/pull/13) first, wait for PyPI publish
2. Then merge this PR (parallel with thebrain-mcp#66)

## Test plan
- [x] 61 tests pass
- [x] `register_operator` with npub — auto-activates DPYC, uses npub for ledger
- [x] `register_operator` invalid npub — rejected with helpful error
- [x] `activate_dpyc` deprecated stub — returns guidance message
- [x] `operator_status`, `check_tax_payment` — work with DPYC session
- [x] `purchase_tax_credits` without DPYC — returns helpful error
- [x] All `certify_purchase` tests unaffected (takes operator_id as param)

🤖 Generated with [Claude Code](https://claude.com/claude-code)