### PR TITLE
Add dpyc_protocol claim to JWT certificates

### DIFF
--- a/src/tollbooth_authority/certificate.py
+++ b/src/tollbooth_authority/certificate.py
@@ -27,6 +27,7 @@ def create_certificate_claims(
         "amount_sats": amount_sats,
         "tax_paid_sats": tax_sats,
         "net_sats": amount_sats - tax_sats,
+        "dpyc_protocol": "dpyp-01-base-certificate",
     }
     if authority_npub:
         claims["authority_npub"] = authority_npub

--- a/tests/test_certificate.py
+++ b/tests/test_certificate.py
@@ -16,6 +16,12 @@ def test_fields_populated():
     assert "jti" in claims
     assert "iat" in claims
     assert "exp" in claims
+    assert "dpyc_protocol" in claims
+
+
+def test_dpyc_protocol_value():
+    claims = create_certificate_claims("op-1", 1000, 20)
+    assert claims["dpyc_protocol"] == "dpyp-01-base-certificate"
 
 
 def test_unique_jti():

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -94,6 +94,10 @@ async def test_certify_purchase_success():
     assert result["net_sats"] == 980
     cache.mark_dirty.assert_called_once_with("op-1")
     cache.flush_user.assert_called_once_with("op-1")
+    # Verify dpyc_protocol claim in JWT
+    import jwt
+    claims = jwt.decode(result["certificate"], options={"verify_signature": False})
+    assert claims["dpyc_protocol"] == "dpyp-01-base-certificate"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Adds `"dpyc_protocol": "dpyp-01-base-certificate"` claim to every signed JWT certificate
- Enables Operators to detect protocol incompatibility at verification time
- Part of DPYP protocol versioning initiative (merge this first)

## Test plan
- [x] `test_fields_populated` asserts `dpyc_protocol` is present
- [x] `test_dpyc_protocol_value` verifies exact string value
- [x] `test_certify_purchase_success` decodes JWT and checks claim
- [x] All 36 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)