### PR TITLE
Pin tollbooth-dpyc >= 0.1.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "python-dotenv>=1.0.0",
     "PyJWT>=2.8.0",
     "cryptography>=42.0.0",
-    "tollbooth-dpyc>=0.1.7",
+    "tollbooth-dpyc>=0.1.10",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
- Pin `tollbooth-dpyc>=0.1.10` to pick up payout processor detection in `btcpay_status` and `AwaitingApproval` hints in `check_payment`

## Merge order
1. Merge + tag tollbooth-dpyc PR #16 → wait for PyPI publish
2. Then merge this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)