### PR TITLE
Fix vault API base URL: api.thebrain.com → api.bra.in

### DIFF
--- a/src/tollbooth_authority/vault.py
+++ b/src/tollbooth_authority/vault.py
@@ -16,7 +16,7 @@ import httpx
 
 logger = logging.getLogger(__name__)
 
-_BASE_URL = "https://api.thebrain.com"
+_BASE_URL = "https://api.bra.in"
 
 
 class TheBrainVault:


### PR DESCRIPTION
## Summary
- `api.thebrain.com` 302-redirects to `app.thebrain.com` (the web UI), not the API
- The correct endpoint is `api.bra.in`, matching `thebrain-mcp`'s client
- Root cause of vault persistence failure — all store/fetch calls silently failed on redirect

## One-line change
```diff
- _BASE_URL = "https://api.thebrain.com"
+ _BASE_URL = "https://api.bra.in"
```

## Test plan
- [ ] After merge + redeploy: `register_operator` → `purchase_tax_credits` → pay → `check_tax_payment`
- [ ] `refresh_config` → `register_operator` → `tax_balance` shows persisted balance
- [ ] Verify vault brain home thought note has index entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)