### PR TITLE
Pin tollbooth-dpyc>=0.1.12 and update vault tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "python-dotenv>=1.0.0",
     "PyJWT>=2.8.0",
     "cryptography>=42.0.0",
-    "tollbooth-dpyc>=0.1.11",
+    "tollbooth-dpyc>=0.1.12",
 ]
 
 [project.optional-dependencies]

--- a/src/tollbooth_authority/__init__.py
+++ b/src/tollbooth_authority/__init__.py
@@ -1,3 +1,3 @@
 """Tollbooth Authority — Certified Purchase Order Service."""
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"

--- a/tests/test_vault.py
+++ b/tests/test_vault.py
@@ -1,9 +1,14 @@
-"""Tests for TheBrainVault with mocked httpx responses."""
+"""Tests for TheBrainVault with mocked internal methods.
+
+These tests verify the vault's ledger operations (store, fetch, snapshot)
+by mocking _discover_members and the low-level API helpers. This mirrors
+the upstream tollbooth-dpyc test pattern.
+"""
 
 from __future__ import annotations
 
 import json
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import httpx
 import pytest
@@ -31,55 +36,83 @@ def vault():
     return v
 
 
+# ---------------------------------------------------------------------------
+# store_ledger
+# ---------------------------------------------------------------------------
+
+
 @pytest.mark.asyncio
 async def test_store_ledger_creates_parent_and_child(vault: TheBrainVault):
-    # Home note is empty (no index)
-    vault._client.get = AsyncMock(side_effect=[
-        _mock_response(200, text="{}"),  # _read_index -> empty
-        _mock_response(200, json_data={"children": []}),  # _get_children
+    """New user: creates ledger parent, registers as hasMember, writes daily child."""
+    vault._discover_members = AsyncMock(return_value={})
+    vault._create_thought = AsyncMock(return_value={"id": "parent-1"})
+    vault._set_note = AsyncMock()
+    vault._get_graph = AsyncMock(return_value={"children": [], "links": []})
+    vault._register_member = AsyncMock()
+    vault._get_children = AsyncMock(return_value=[])
+
+    # Second call to _create_thought for the daily child
+    vault._create_thought = AsyncMock(side_effect=[
+        {"id": "parent-1"},  # ledger parent
+        {"id": "child-1"},   # daily child
     ])
-    vault._client.post = AsyncMock(side_effect=[
-        _mock_response(200, json_data={"id": "parent-1"}),  # _create_thought (parent)
-        _mock_response(200),  # _write_index
-        _mock_response(200, json_data={"id": "child-1"}),  # _create_thought (child)
-        _mock_response(200),  # _set_note
-    ])
+
+    result = await vault.store_ledger("op-1", '{"balance": 500}')
+    assert result == "child-1"
+    assert vault._register_member.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_store_ledger_existing_user_reuses_parent(vault: TheBrainVault):
+    """Existing user: finds member via _discover_members, writes to daily child."""
+    vault._discover_members = AsyncMock(return_value={"op-1/ledger": "parent-1"})
+    vault._get_children = AsyncMock(return_value=[])
+    vault._create_thought = AsyncMock(return_value={"id": "child-1"})
+    vault._set_note = AsyncMock()
 
     result = await vault.store_ledger("op-1", '{"balance": 500}')
     assert result == "child-1"
 
 
+# ---------------------------------------------------------------------------
+# fetch_ledger
+# ---------------------------------------------------------------------------
+
+
 @pytest.mark.asyncio
 async def test_fetch_ledger_returns_none_for_unknown_user(vault: TheBrainVault):
-    vault._client.get = AsyncMock(return_value=_mock_response(200, text="{}"))
+    vault._discover_members = AsyncMock(return_value={})
+
     result = await vault.fetch_ledger("unknown-user")
     assert result is None
 
 
 @pytest.mark.asyncio
 async def test_fetch_ledger_reads_most_recent_child(vault: TheBrainVault):
-    index = json.dumps({"op-1/ledger": "ledger-parent-1"})
-    vault._client.get = AsyncMock(side_effect=[
-        _mock_response(200, text=index),  # _read_index
-        _mock_response(200, json_data={"children": [  # _get_children
-            {"id": "day-1", "name": "2026-02-17"},
-            {"id": "day-2", "name": "2026-02-18"},
-        ]}),
-        _mock_response(200, text='{"balance": 300}'),  # _get_note (most recent)
+    """Finds ledger parent via _discover_members, reads most recent daily child."""
+    vault._discover_members = AsyncMock(return_value={"op-1/ledger": "parent-1"})
+    vault._get_children = AsyncMock(return_value=[
+        {"id": "day-1", "name": "2026-02-17"},
+        {"id": "day-2", "name": "2026-02-18"},
     ])
+    vault._get_note = AsyncMock(return_value='{"balance": 300}')
 
     result = await vault.fetch_ledger("op-1")
     assert result == '{"balance": 300}'
+    # Should read the most recent child (day-2)
+    vault._get_note.assert_called_with("day-2")
+
+
+# ---------------------------------------------------------------------------
+# snapshot_ledger
+# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
 async def test_snapshot_ledger_creates_timestamped_child(vault: TheBrainVault):
-    index = json.dumps({"op-1/ledger": "ledger-parent-1"})
-    vault._client.get = AsyncMock(return_value=_mock_response(200, text=index))
-    vault._client.post = AsyncMock(side_effect=[
-        _mock_response(200, json_data={"id": "snap-1"}),  # _create_thought
-        _mock_response(200),  # _set_note
-    ])
+    vault._discover_members = AsyncMock(return_value={"op-1/ledger": "parent-1"})
+    vault._create_thought = AsyncMock(return_value={"id": "snap-1"})
+    vault._set_note = AsyncMock()
 
     result = await vault.snapshot_ledger("op-1", '{"balance": 100}', "2026-02-18T12:00:00Z")
     assert result == "snap-1"
@@ -87,6 +120,7 @@ async def test_snapshot_ledger_creates_timestamped_child(vault: TheBrainVault):
 
 @pytest.mark.asyncio
 async def test_snapshot_returns_none_without_ledger(vault: TheBrainVault):
-    vault._client.get = AsyncMock(return_value=_mock_response(200, text="{}"))
+    vault._discover_members = AsyncMock(return_value={})
+
     result = await vault.snapshot_ledger("op-1", '{}', "2026-02-18T12:00:00Z")
     assert result is None


### PR DESCRIPTION
## Summary
- Bumps `tollbooth-dpyc` dependency from `>=0.1.11` to `>=0.1.12` (link-based member discovery replaces JSON-note indices)
- Fixes `__init__.py` version to match `pyproject.toml` (0.1.0 → 0.1.1)
- Rewrites vault tests to mock `_discover_members` instead of raw HTTP calls, matching upstream test pattern

## Test plan
- [x] All 63 tests pass locally with tollbooth-dpyc 0.1.12 installed from source
- [ ] Merge after tollbooth-dpyc 0.1.12 is published to PyPI

🤖 Generated with [Claude Code](https://claude.com/claude-code)