### PR TITLE
Pin tollbooth-dpyc>=0.1.13 for Azure affinity fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "python-dotenv>=1.0.0",
     "PyJWT>=2.8.0",
     "cryptography>=42.0.0",
-    "tollbooth-dpyc>=0.1.12",
+    "tollbooth-dpyc>=0.1.13",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
- Bumps minimum tollbooth-dpyc to 0.1.13
- Inherits Azure App Service ARRAffinity fix for vault member discovery

## Test plan
- [x] 63 tollbooth-authority tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)