### PR TITLE
Pin tollbooth-dpyc >= 0.1.14

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "python-dotenv>=1.0.0",
     "PyJWT>=2.8.0",
     "cryptography>=42.0.0",
-    "tollbooth-dpyc>=0.1.13",
+    "tollbooth-dpyc>=0.1.14",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
- Pins tollbooth-dpyc >= 0.1.14 which fixes vault member discovery to use children array instead of unreliable link labels

## Test plan
- [x] All 63 tollbooth-authority tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)