### PR TITLE
Pin tollbooth-dpyc>=0.1.15

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "python-dotenv>=1.0.0",
     "PyJWT>=2.8.0",
     "cryptography>=42.0.0",
-    "tollbooth-dpyc>=0.1.14",
+    "tollbooth-dpyc>=0.1.15",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
- Pin tollbooth-dpyc>=0.1.15 for soft-delete vault support

🤖 Generated with [Claude Code](https://claude.com/claude-code)