### PR TITLE
Remove refresh_config tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,6 @@ To run your own Authority instance, set these environment variables:
 | `tax_balance` | Check your current tax balance, total deposited, total consumed, and pending invoices. |
 | `operator_status` | View your registration status, balance summary, and the Authority's Ed25519 public key. |
 | `certify_purchase` | The core machine-to-machine tool. Deducts tax and returns an EdDSA-signed JWT certificate. |
-| `refresh_config` | Hot-reload environment variables without redeploying the service. |
 
 ## Development
 


### PR DESCRIPTION
## Summary
- Removes the `refresh_config` MCP tool from the Authority server
- Removes the tool reference from instructions string and README

Horizon redeploy takes ~60 seconds, making hot-reload unnecessary complexity.

## Test plan
- [x] All 64 tests pass (`venv/bin/pytest tests/ -v`)
- [ ] Verify deployment on FastMCP Cloud after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)