### PR TITLE
Adopt tranche-based credit expiration from tollbooth-dpyc 0.1.16

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "python-dotenv>=1.0.0",
     "PyJWT>=2.8.0",
     "cryptography>=42.0.0",
-    "tollbooth-dpyc>=0.1.15",
+    "tollbooth-dpyc>=0.1.16",
 ]
 
 [project.optional-dependencies]

--- a/src/tollbooth_authority/server.py
+++ b/src/tollbooth_authority/server.py
@@ -449,6 +449,7 @@ async def purchase_tax_credits(
         btcpay, cache, user_id, amount_sats,
         tier_config_json=s.btcpay_tier_config,
         user_tiers_json=s.btcpay_user_tiers,
+        default_credit_ttl_seconds=None,  # Authority balances never expire
     )
 
 
@@ -494,6 +495,7 @@ async def check_tax_payment(
         btcpay, cache, user_id, invoice_id,
         tier_config_json=s.btcpay_tier_config,
         user_tiers_json=s.btcpay_user_tiers,
+        default_credit_ttl_seconds=None,  # Authority balances never expire
         royalty_address=s.upstream_authority_address or None,
         royalty_percent=s.upstream_tax_percent / 100,
         royalty_min_sats=s.upstream_tax_min_sats,
@@ -533,6 +535,7 @@ async def tax_balance() -> dict[str, Any]:
                 btcpay, cache, user_id,
                 tier_config_json=s.btcpay_tier_config,
                 user_tiers_json=s.btcpay_user_tiers,
+                default_credit_ttl_seconds=None,  # Authority balances never expire
             )
             if recon["reconciled"] > 0:
                 logger.info(
@@ -546,6 +549,7 @@ async def tax_balance() -> dict[str, Any]:
         cache, user_id,
         tier_config_json=s.btcpay_tier_config,
         user_tiers_json=s.btcpay_user_tiers,
+        default_credit_ttl_seconds=None,  # Authority balances never expire
     )
 
 


### PR DESCRIPTION
## Summary
- Pin `tollbooth-dpyc>=0.1.16` for tranche-based `UserLedger` API
- Pass `default_credit_ttl_seconds=None` to all credit tool calls — Authority tax balances never expire
- Update all test fixtures for tranche-based UserLedger (v4 schema)

## Test plan
- [x] All 64 tests pass locally
- [ ] Verify Authority `tax_balance` works after deploy
- [ ] Verify `certify_purchase` still deducts and signs correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)