### PR TITLE
Bump tollbooth-dpyc[nostr] to 0.26.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "pydantic>=2.0.0",
     "pydantic-settings>=2.0.0",
     "python-dotenv>=1.0.0",
-    "tollbooth-dpyc[nostr]==0.25.0",
+    "tollbooth-dpyc[nostr]==0.26.0",
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -1275,22 +1275,22 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23.0" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
-    { name = "tollbooth-dpyc", extras = ["nostr"], specifier = "==0.25.0" },
+    { name = "tollbooth-dpyc", extras = ["nostr"], specifier = "==0.26.0" },
 ]
 provides-extras = ["dev"]
 
 [[package]]
 name = "tollbooth-dpyc"
-version = "0.25.0"
+version = "0.26.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
     { name = "httpx" },
     { name = "pynostr" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2f/0c/ff4a334081b74f89c27eeb4aad8ed6d1ffb3eb7fd655d734df89db214184/tollbooth_dpyc-0.25.0.tar.gz", hash = "sha256:d6b202ac571da6fb674c1ff83d497fc7d91570a8f4ea4f1a4c1ff310ede3f8c4", size = 2260621, upload-time = "2026-05-19T20:11:24.171Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/95/8b9366840cfd27e796fc7538f00f583ec5a98efa6af4aea3eedda2c893b5/tollbooth_dpyc-0.26.0.tar.gz", hash = "sha256:43b3e6da8a78a3284c7d05d6047d8d4bb584a63fa4fdd63b13f85e70830a785a", size = 2272090, upload-time = "2026-05-23T12:19:22.622Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0a/87/bfbd9f80f4a86d418a2c16dfe82cec8cd521063a65e52ab26a536152265d/tollbooth_dpyc-0.25.0-py3-none-any.whl", hash = "sha256:707a1781dd6010230a2e787c15f0db7994ee12145ffd93081feafcc9aefcd438", size = 261345, upload-time = "2026-05-19T20:11:22.053Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/d9/638fdd3fa929495824e86296adce92a8526e3b09c39a352fe79e30eb6f22/tollbooth_dpyc-0.26.0-py3-none-any.whl", hash = "sha256:e929fb71bf6728f6739f2f2ce4fe270926b5d3f8f97487df01ffbb81137682cf", size = 263183, upload-time = "2026-05-23T12:19:20.416Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
Authority will now enforce the new authority_proof requirement on register/update/deregister_operator (wheel 0.26.0). Existing Studio versions calling these without authority_proof will receive error_code: authority_consent_required until the Studio is rebuilt.