### PR TITLE
docs: backfill CHANGELOG (SDK pin tracking through 0.44.15)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this project will be documented in this file.
 Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.10.1] — 2026-06-11
+- chore: track tollbooth-dpyc through 0.44.15 — SDK audit hardening (correctness fixes for credit-tranche expiration in 0.44.9 and proof-reply handling in 0.44.10; blocking mypy + coverage gates). No wire-API changes.
+
 ## [0.10.0] — 2026-05-19
 
 ### Changed — sync with tollbooth-dpyc 0.25.0


### PR DESCRIPTION
Resolves CHANGELOG-behind-pyproject drift: records the already-shipped version's SDK pin tracking (tollbooth-dpyc → 0.44.15). Docs-only; no code or version change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)