### PR TITLE
Register in official MCP Registry (OIDC)

### DIFF
--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -1,0 +1,33 @@
+name: Publish to MCP Registry
+
+on:
+  workflow_dispatch:
+  push:
+    tags: ["v*"]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write   # required for GitHub OIDC authentication
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Install mcp-publisher
+        run: |
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+
+      - name: Sync server.json version from tag
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          jq --arg v "$VERSION" '.version = $v' server.json > server.tmp && mv server.tmp server.json
+
+      - name: Authenticate to MCP Registry (OIDC)
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish server to MCP Registry
+        run: ./mcp-publisher publish

--- a/server.json
+++ b/server.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.lonniev/tollbooth-authority",
+  "description": "Tollbooth Authority — Certified Purchase Order Service for DPYC operators",
+  "version": "0.11.0",
+  "repository": {
+    "url": "https://github.com/lonniev/tollbooth-authority",
+    "source": "github"
+  },
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://tollbooth-authority.fastmcp.app/mcp"
+    }
+  ]
+}


### PR DESCRIPTION
Registers this server in the official [MCP Registry](https://registry.modelcontextprotocol.io) as `io.github.lonniev/tollbooth-authority`.

- Remote transport: `streamable-http` at the FastMCP endpoint
- Publishing uses **GitHub OIDC** — no secrets (`id-token: write`)
- Trigger: `workflow_dispatch` or pushing a `v*` tag
- server.json passes `mcp-publisher validate`

🤖 Generated with [Claude Code](https://claude.com/claude-code)