### PR TITLE
ci: sync DPYC Software Factory callers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# Money-path human gate. Every source/config change requires @lonniev review
+# (CODEOWNERS + branch protection); the agentic Journeyman may open PRs but nothing
+# lands without you. Only tests and docs are uncovered, so path-gated auto-merge
+# can land those unattended.
+* @lonniev
+/tests/
+*.md

--- a/.github/workflows/agentic-auto-merge.yml
+++ b/.github/workflows/agentic-auto-merge.yml
@@ -1,0 +1,16 @@
+# Thin caller — path-gated auto-merge. Fires when QA applies qa/pass.
+name: Agentic Auto-merge
+
+on:
+  pull_request:
+    types: [labeled]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  gate:
+    if: github.event.label.name == 'qa/pass'
+    uses: lonniev/dpyc-community/.github/workflows/auto-merge.yml@main
+    secrets: inherit

--- a/.github/workflows/agentic-engineering.yml
+++ b/.github/workflows/agentic-engineering.yml
@@ -1,0 +1,19 @@
+# Thin caller — Role 2 (Engineering). Fires only when the Service Desk applies agent/fix.
+name: Agentic Engineering
+
+on:
+  issues:
+    types: [labeled]
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  implement:
+    if: github.event.label.name == 'agent/fix'
+    uses: lonniev/dpyc-community/.github/workflows/engineering.yml@main
+    secrets: inherit
+    with:
+      model: claude-opus-4-8

--- a/.github/workflows/agentic-escalation.yml
+++ b/.github/workflows/agentic-escalation.yml
@@ -1,0 +1,15 @@
+# Thin caller — cross-repo escalation. Fires when an agent labels an issue blocked/upstream.
+name: Agentic Escalation
+
+on:
+  issues:
+    types: [labeled]
+
+permissions:
+  issues: write
+
+jobs:
+  escalate:
+    if: github.event.label.name == 'blocked/upstream'
+    uses: lonniev/dpyc-community/.github/workflows/escalation.yml@main
+    secrets: inherit

--- a/.github/workflows/agentic-pr-dialogue.yml
+++ b/.github/workflows/agentic-pr-dialogue.yml
@@ -1,0 +1,33 @@
+# Thin caller — PR Dialogue. Fires when a reviewer mentions @journeyman in a PR
+# comment or review, so the Journeyman can answer the bench's question on the record.
+name: Agentic PR Dialogue
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  answer:
+    # Only on PRs, only when the Journeyman is summoned, and never on the bot's own
+    # comments — that last guard is what stops an answer from re-triggering the workflow.
+    if: >-
+      github.event.sender.login != 'dpyc-agentic-desk[bot]' &&
+      (
+        (github.event_name == 'issue_comment' && github.event.issue.pull_request != null && contains(github.event.comment.body, '@journeyman')) ||
+        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@journeyman')) ||
+        (github.event_name == 'pull_request_review' && github.event.review.body != null && contains(github.event.review.body, '@journeyman'))
+      )
+    uses: lonniev/dpyc-community/.github/workflows/pr-dialogue.yml@main
+    secrets: inherit
+    with:
+      pr_number: ${{ github.event.issue.number || github.event.pull_request.number }}
+      model: claude-opus-4-8

--- a/.github/workflows/agentic-qa.yml
+++ b/.github/workflows/agentic-qa.yml
@@ -1,0 +1,25 @@
+# Thin caller — Role 3 (QA). Reviews only the Engineering agent's own PRs
+# (same-repo branch agent/fix-*). Uses pull_request (never pull_request_target):
+# GitHub withholds secrets from fork PRs, so a stranger's PR can't run QA or reach
+# the nsec/App token — the load-bearing fork-secrets property. Doctrine-enforced by
+# the doctrine linter's pull_request_target ban.
+name: Agentic QA
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  review:
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      startsWith(github.event.pull_request.head.ref, 'agent/fix-')
+    uses: lonniev/dpyc-community/.github/workflows/qa.yml@main
+    secrets: inherit
+    with:
+      model: claude-opus-4-8

--- a/.github/workflows/agentic-service-desk.yml
+++ b/.github/workflows/agentic-service-desk.yml
@@ -1,0 +1,17 @@
+# Thin caller — Role 1 (Service Desk). Logic lives once in dpyc-community.
+name: Agentic Service Desk
+
+on:
+  issues:
+    types: [opened, reopened]
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  triage:
+    uses: lonniev/dpyc-community/.github/workflows/service-desk.yml@main
+    secrets: inherit
+    with:
+      model: claude-sonnet-5


### PR DESCRIPTION
Fans out the canonical thin callers from `dpyc-community/scripts/factory-callers/`, so this repo runs the current factory set — including the `@journeyman` PR-dialogue reviewer. All logic lives in the reusable workflows these call (dpyc-community @main); the callers themselves are boilerplate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)