### PR TITLE
ci: sync DPYC Software Factory callers

### DIFF
--- a/.github/workflows/agentic-approval-merge.yml
+++ b/.github/workflows/agentic-approval-merge.yml
@@ -1,0 +1,18 @@
+# Thin caller — merge on approval. Logic lives once in dpyc-community.
+# When the repo owner approves a PR, GitHub native auto-merge is enabled and the PR lands
+# once branch protection is satisfied (required checks green + code-owner review). Safe by
+# construction: --auto never merges on a red check.
+name: Agentic Merge on Approval
+
+on:
+  pull_request_review:
+    types: [submitted]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  merge:
+    uses: lonniev/dpyc-community/.github/workflows/approval-merge.yml@main
+    secrets: inherit


### PR DESCRIPTION
Fans out the canonical thin callers from `dpyc-community/scripts/factory-callers/`, so this repo runs the current factory set — including the `@journeyman` PR-dialogue reviewer. All logic lives in the reusable workflows these call (dpyc-community @main); the callers themselves are boilerplate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)