### PR TITLE
ci: sync DPYC Software Factory callers

### DIFF
--- a/.github/workflows/agentic-pr-dialogue.yml
+++ b/.github/workflows/agentic-pr-dialogue.yml
@@ -30,4 +30,4 @@ jobs:
     secrets: inherit
     with:
       pr_number: ${{ github.event.issue.number || github.event.pull_request.number }}
-      model: claude-opus-4-8
+      model: claude-sonnet-5

--- a/.github/workflows/agentic-qa.yml
+++ b/.github/workflows/agentic-qa.yml
@@ -22,4 +22,4 @@ jobs:
     uses: lonniev/dpyc-community/.github/workflows/qa.yml@main
     secrets: inherit
     with:
-      model: claude-opus-4-8
+      model: claude-sonnet-5


### PR DESCRIPTION
Fans out the canonical thin callers from `dpyc-community/scripts/factory-callers/`, so this repo runs the current factory set — including the `@journeyman` PR-dialogue reviewer. All logic lives in the reusable workflows these call (dpyc-community @main); the callers themselves are boilerplate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)