### PR TITLE
ci: sync DPYC Software Factory callers

### DIFF
--- a/.github/workflows/agentic-housekeeper.yml
+++ b/.github/workflows/agentic-housekeeper.yml
@@ -5,7 +5,7 @@ name: Agentic Housekeeper
 
 on:
   schedule:
-    - cron: "17 13 * * *"   # daily ~13:17 UTC; offset minute to dodge top-of-hour cron congestion
+    - cron: "17 13 * * 1"   # weekly, Mondays ~13:17 UTC; low fleet churn makes daily unnecessary
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Fans out the canonical thin callers from `dpyc-community/scripts/factory-callers/`, so this repo runs the current factory set — including the `@journeyman` PR-dialogue reviewer. All logic lives in the reusable workflows these call (dpyc-community @main); the callers themselves are boilerplate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)