### PR TITLE
release: v0.11.2 — track tollbooth-dpyc 0.63.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.11.2 — 2026-07-16
+
+### Changed — track tollbooth-dpyc 0.63.3
+
+- Bumped the pinned SDK to 0.63.3 (npub-proof challenge DM now stamps the request time). Also cuts a release for changes accumulated since the last tag.
+
 ## [Unreleased]
 
 ## [0.11.1] — 2026-07-09

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tollbooth-authority"
-version = "0.11.1"
+version = "0.11.2"
 description = "Tollbooth Authority — Certified Purchase Order Service"
 readme = "README.md"
 license = "Apache-2.0"
@@ -17,7 +17,7 @@ dependencies = [
     "pydantic>=2.0.0",
     "pydantic-settings>=2.0.0",
     "python-dotenv>=1.0.0",
-    "tollbooth-dpyc[nostr]==0.63.2",
+    "tollbooth-dpyc[nostr]==0.63.3",
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -1275,22 +1275,22 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23.0" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
-    { name = "tollbooth-dpyc", extras = ["nostr"], specifier = "==0.63.2" },
+    { name = "tollbooth-dpyc", extras = ["nostr"], specifier = "==0.63.3" },
 ]
 provides-extras = ["dev"]
 
 [[package]]
 name = "tollbooth-dpyc"
-version = "0.63.2"
+version = "0.63.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
     { name = "httpx" },
     { name = "pynostr" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/91/a8/051145a26e7560de1072e4f843471bb27902d872ddf6ac11b770981c15b6/tollbooth_dpyc-0.63.2.tar.gz", hash = "sha256:81bd1d645770764eac670e87cab3aca6013dc620a3306400e928f327c2f563f4", size = 2594257, upload-time = "2026-07-15T02:23:09.85Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c8/f7/2f0c65ba176ca886b8436e92e021c099f04e52dd391b04f23845a38c0d14/tollbooth_dpyc-0.63.3.tar.gz", hash = "sha256:00124eb637f2e5138f02c886471a35dd6c843736b9fbbf4c513df5b73c143836", size = 2595302, upload-time = "2026-07-16T19:26:22.739Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/50/44/937e0a381d7d3c5b505dfce818386a05d89495f88a6eb1fe0867ecf1dca4/tollbooth_dpyc-0.63.2-py3-none-any.whl", hash = "sha256:4e94973f7dc19026c99be6df94429910a6febf3105c9b5330254055300881010", size = 359545, upload-time = "2026-07-15T02:23:08.239Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/cb/181f1f1bdbf8419380e02930fb7d4aea341d753cea90bbaf7b8d798b5b42/tollbooth_dpyc-0.63.3-py3-none-any.whl", hash = "sha256:4d71874bc2a17a5aa1457c6c32c057ba309b2597a78b4ca80ca3ade1cfc805ab", size = 359680, upload-time = "2026-07-16T19:26:20.679Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
Round-robin fleet refresh: pin the SDK to the leading wheel **0.63.3** (+ uv.lock regen) and cut a release. CI gates the SDK jump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)