### PR TITLE
ci: sync DPYC Software Factory callers

### DIFF
--- a/.github/workflows/agentic-service-desk.yml
+++ b/.github/workflows/agentic-service-desk.yml
@@ -3,7 +3,10 @@ name: Agentic Service Desk
 
 on:
   issues:
-    types: [opened, reopened]
+    # opened/reopened: normal intake. labeled: the credit canary re-fires Porter
+    # on recovery by adding agent/retriage — the guard below keeps it from looping
+    # on Porter's OWN type/sev/area labels.
+    types: [opened, reopened, labeled]
 
 permissions:
   contents: read
@@ -11,6 +14,7 @@ permissions:
 
 jobs:
   triage:
+    if: ${{ github.event.action != 'labeled' || github.event.label.name == 'agent/retriage' }}
     uses: lonniev/dpyc-community/.github/workflows/service-desk.yml@main
     secrets: inherit
     with:


### PR DESCRIPTION
Fans out the canonical thin callers from `dpyc-community/scripts/factory-callers/`, so this repo runs the current factory set — including the `@journeyman` PR-dialogue reviewer. All logic lives in the reusable workflows these call (dpyc-community @main); the callers themselves are boilerplate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)