### PR TITLE
ci: sync DPYC Software Factory callers

### DIFF
--- a/.github/workflows/agentic-pr-dialogue.yml
+++ b/.github/workflows/agentic-pr-dialogue.yml
@@ -19,12 +19,18 @@ jobs:
   answer:
     # Only on PRs, only when the Journeyman is summoned, and never on the bot's own
     # comments — that last guard is what stops an answer from re-triggering the workflow.
+    #
+    # YIELDS TO PR REVISION. Dialogue explains; Revision changes code. Both are summoned
+    # by "@journeyman", so this guard hands the two unambiguous change-order forms to
+    # agentic-pr-revision.yml and keeps only the questions: a comment carrying the
+    # "@journeyman revise" verb, and a changes-requested review, are Revision's. Without
+    # these negatives BOTH roles would fire on the same event.
     if: >-
       github.event.sender.login != 'dpyc-agentic-desk[bot]' &&
       (
-        (github.event_name == 'issue_comment' && github.event.issue.pull_request != null && contains(github.event.comment.body, '@journeyman')) ||
-        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@journeyman')) ||
-        (github.event_name == 'pull_request_review' && github.event.review.body != null && contains(github.event.review.body, '@journeyman'))
+        (github.event_name == 'issue_comment' && github.event.issue.pull_request != null && contains(github.event.comment.body, '@journeyman') && !contains(github.event.comment.body, '@journeyman revise')) ||
+        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@journeyman') && !contains(github.event.comment.body, '@journeyman revise')) ||
+        (github.event_name == 'pull_request_review' && github.event.review.state != 'changes_requested' && github.event.review.body != null && contains(github.event.review.body, '@journeyman') && !contains(github.event.review.body, '@journeyman revise'))
       )
     uses: lonniev/dpyc-community/.github/workflows/pr-dialogue.yml@main
     secrets: inherit

--- a/.github/workflows/agentic-pr-revision.yml
+++ b/.github/workflows/agentic-pr-revision.yml
@@ -1,0 +1,43 @@
+# Thin caller — PR Revision. Fires when the repository OWNER sends a PR back for
+# changes, so the Journeyman can return to the bench and make them.
+#
+# Two entry points, both owner-only: GitHub's native "Request changes" review (the
+# ergonomic path — the platform already distinguishes a question from a change order),
+# and an explicit "@journeyman revise" comment for a quick note. A plain "@journeyman"
+# still reaches the READ-ONLY PR Dialogue, which anyone may summon.
+name: Agentic PR Revision
+
+on:
+  pull_request_review:
+    types: [submitted]
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  revise:
+    # SECURITY BOUNDARY — read this as carefully as a token scope. This is the only role
+    # that is both human-triggered and write-capable, so the author_association == 'OWNER'
+    # test is what stands in for pr-dialogue's "no write tools, read-only tokens". The
+    # precedent is approval-merge.yml, which gates the merge on the same association.
+    # The bot guard stops the Journeyman's own comment from summoning it again.
+    if: >-
+      github.event.sender.login != 'dpyc-agentic-desk[bot]' &&
+      (
+        (github.event_name == 'pull_request_review' &&
+         github.event.review.state == 'changes_requested' &&
+         github.event.review.author_association == 'OWNER') ||
+        (github.event_name == 'issue_comment' &&
+         github.event.issue.pull_request != null &&
+         contains(github.event.comment.body, '@journeyman revise') &&
+         github.event.comment.author_association == 'OWNER')
+      )
+    uses: lonniev/dpyc-community/.github/workflows/pr-revision.yml@main
+    secrets: inherit
+    with:
+      pr_number: ${{ github.event.issue.number || github.event.pull_request.number }}
+      model: claude-opus-4-8


### PR DESCRIPTION
Fans out the canonical thin callers from `dpyc-community/scripts/factory-callers/`, so this repo runs the current factory set — including the `@journeyman` PR-dialogue reviewer. All logic lives in the reusable workflows these call (dpyc-community @main); the callers themselves are boilerplate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)