### PR TITLE
chore(deps): bump tollbooth-dpyc to 0.78.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "pydantic>=2.0.0",
     "pydantic-settings>=2.0.0",
     "python-dotenv>=1.0.0",
-    "tollbooth-dpyc[nostr]==0.76.0",
+    "tollbooth-dpyc[nostr]==0.78.0",
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -1275,22 +1275,22 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23.0" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
-    { name = "tollbooth-dpyc", extras = ["nostr"], specifier = "==0.76.0" },
+    { name = "tollbooth-dpyc", extras = ["nostr"], specifier = "==0.78.0" },
 ]
 provides-extras = ["dev"]
 
 [[package]]
 name = "tollbooth-dpyc"
-version = "0.76.0"
+version = "0.78.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
     { name = "httpx" },
     { name = "pynostr" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8b/d7/5bbbc9211e3b0f746d1453928657ba83f38d69d80301f276ed31019a6be4/tollbooth_dpyc-0.76.0.tar.gz", hash = "sha256:ff68b824cb672631023f445c9a94e1a0765248704267f1cf94db96d774bf9424", size = 2693366, upload-time = "2026-07-30T18:31:27.518Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6e/b3/5b0a6ab35147fba6ffb66d4d3312a82c574754d7b01b564e2eb5bc9682df/tollbooth_dpyc-0.78.0.tar.gz", hash = "sha256:76bfa7190993bfa98016075b2d329edae8ff2af4ccb59bae388593f1cda1c222", size = 2714471, upload-time = "2026-08-01T21:19:27.513Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1a/97/e4d72c3f895a7994899511e59be3b4bc86cf608efe5f3f5d6736f4868bcb/tollbooth_dpyc-0.76.0-py3-none-any.whl", hash = "sha256:16efd495892e461daff55e38df1043f0445131ad1b6b58ea867de9ea3184aa71", size = 413340, upload-time = "2026-07-30T18:31:25.607Z" },
+    { url = "https://files.pythonhosted.org/packages/23/2a/98134a0115cf461759a448cc1e5e4888bfad4f0acaa57b67f41916f6fa89/tollbooth_dpyc-0.78.0-py3-none-any.whl", hash = "sha256:ea196384ec86d3e7982ee71cb99eb07f5cb6522cc7c478a22fc2264129546930", size = 424971, upload-time = "2026-08-01T21:19:25.933Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
Fleet release of `tollbooth-dpyc` 0.78.0 — token-exchange fault taxonomy (#173) and ledger CAS write-through migration (#171). Extras preserved; lock regenerated where present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)