### PR TITLE
chore(deps): bump tollbooth-dpyc to 0.79.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "pydantic>=2.0.0",
     "pydantic-settings>=2.0.0",
     "python-dotenv>=1.0.0",
-    "tollbooth-dpyc[nostr]==0.78.0",
+    "tollbooth-dpyc[nostr]==0.79.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Fleet release of `tollbooth-dpyc` 0.79.0 — token-exchange fault taxonomy (#173) and ledger CAS write-through migration (#171). Extras preserved; lock regenerated where present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)