### PR TITLE
chore: sync version files to pyproject 0.11.2

### DIFF
--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.lonniev/tollbooth-authority",
   "description": "Tollbooth Authority — Certified Purchase Order Service for DPYC operators",
-  "version": "0.11.0",
+  "version": "0.11.2",
   "repository": {
     "url": "https://github.com/lonniev/tollbooth-authority",
     "source": "github"


### PR DESCRIPTION
`server.json` (and `frontend/package.json` where present) stated a version that had drifted from `pyproject.toml`, the source of truth. Nothing reads these values back, so nothing caught it.

**No wrong version was ever published.** `publish-mcp-registry.yml` rewrites `server.json`'s `.version` from the git tag at publish time. The stale committed value only misled humans and agents reading the file.

Audited across the fleet 2026-08-03: 10 of 12 repos had drifted, the worst by eight minor versions (excalibur `0.29.1` vs `0.37.3`). `/release` now bumps every version file rather than `pyproject.toml` alone, so this stops re-accumulating.

Version files only — no code changes.